### PR TITLE
Upgrade AssertJ

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.3")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.10.3")
-    testImplementation("org.assertj:assertj-core:3.16.1")
+    testImplementation("org.assertj:assertj-core:3.26.3")
 }
 
 kotlin {

--- a/src/test/kotlin/com/github/dkoval/leetcode/challenge/DataStreamDisjointIntervalsTest.kt
+++ b/src/test/kotlin/com/github/dkoval/leetcode/challenge/DataStreamDisjointIntervalsTest.kt
@@ -53,7 +53,7 @@ private fun DataStreamDisjointIntervals.SummaryRanges.test(commands: List<Comman
     commands.forEach { command ->
         when (command) {
             is Command.Add -> addNum(command.value)
-            is Command.GetIntervals -> assertThat(intervals).containsExactlyElementsOf(command.expected)
+            is Command.GetIntervals -> assertThat(intervals.asIterable()).containsExactlyElementsOf(command.expected)
         }
     }
 }

--- a/src/test/kotlin/com/github/dkoval/leetcode/challenge/FindAllGroupsOfFarmlandTest.kt
+++ b/src/test/kotlin/com/github/dkoval/leetcode/challenge/FindAllGroupsOfFarmlandTest.kt
@@ -60,5 +60,5 @@ internal class FindAllGroupsOfFarmlandTest {
 
 private fun FindAllGroupsOfFarmland.test(land: Array<IntArray>, expected: Array<IntArray>) {
     val actual = findFarmland(land)
-    assertThat(actual).containsExactlyInAnyOrder(*expected)
+    assertThat(actual.asIterable()).containsExactlyInAnyOrder(*expected)
 }

--- a/src/test/kotlin/com/github/dkoval/leetcode/challenge/KClosestPointsToOriginTest.kt
+++ b/src/test/kotlin/com/github/dkoval/leetcode/challenge/KClosestPointsToOriginTest.kt
@@ -61,6 +61,6 @@ internal class KClosestPointsToOriginTest {
         expected: Array<IntArray>
     ) {
         val actual = kClosest(points, K)
-        assertThat(actual).containsExactlyInAnyOrder(*expected)
+        assertThat(actual.asIterable()).containsExactlyInAnyOrder(*expected)
     }
 }

--- a/src/test/kotlin/com/github/dkoval/leetcode/challenge/SortMatrixDiagonallyTest.kt
+++ b/src/test/kotlin/com/github/dkoval/leetcode/challenge/SortMatrixDiagonallyTest.kt
@@ -89,6 +89,6 @@ internal class SortMatrixDiagonallyTest {
 
     fun SortMatrixDiagonally.test(mat: Array<IntArray>, expected: Array<IntArray>) {
         val actual = diagonalSort(mat)
-        assertThat(actual).containsExactly(*expected)
+        assertThat(actual.asIterable()).containsExactly(*expected)
     }
 }


### PR DESCRIPTION
- Bump `assertj` to `v3.26.3`
- fix breaking API changes